### PR TITLE
Update tasks.json to the latest version of vscode

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -7,22 +7,32 @@
 // ${cwd}: the current working directory of the spawned process
 
 // A task runner that calls gulp build
+
 {
 	"version": "0.1.0",
-
-	// The command is gulp
 	"command": "gulp",
-
-	// The command is a shell script
 	"isShellCommand": true,
-
-	// Show the output window only if unrecognized errors occur.
-	"showOutput": "silent",
-
-	// args is the HelloWorld program to compile.
-	"args": ["build"],
-
-	// use the standard tsc problem matcher to find compile problems
-	// in the output.
-	"problemMatcher": "$tsc"
+	"tasks": [
+		{
+			"taskName": "build",
+			// Make this the default build command.
+			"isBuildCommand": true,
+			// Show the output window only if unrecognized errors occur.
+			"showOutput": "silent",
+			// Use the standard less compilation problem matcher.
+			"problemMatcher": [
+				"$gulp-tsc"
+			]
+		},
+		{
+			"taskName": "watch",
+            "isWatching": true,
+			// Show the output window only if unrecognized errors occur.
+			"showOutput": "silent",
+			// Use the standard less compilation problem matcher.
+			"problemMatcher": [
+				"$gulp-tsc"
+			]
+		}
+	]
 }


### PR DESCRIPTION
Lists the gulp tasks `build` and `watch` in VSCode, and marks `watch` as a watcher so it will be run in the background with the correct `gulp-tsc` error matchers. 